### PR TITLE
Compatibilité eclipse 22.12

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-commons/bindgen.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-commons/bindgen.properties
@@ -1,5 +1,7 @@
 scope=fr.openwide.core.commons,java.util,java.lang
 skipBindKeyword=true
 bindingPathSuperClass=fr.openwide.core.commons.util.binding.AbstractCoreBinding
+
 skipAttribute.fr.openwide.core.commons.util.fieldpath.FieldPath.root=true
 skipAttribute.java.lang.Iterable.spliterator=true
+skipAttribute.java.lang.Enum.describeConstable=true

--- a/owsi-core/owsi-core-components/owsi-core-component-commons/pom.xml
+++ b/owsi-core/owsi-core-components/owsi-core-component-commons/pom.xml
@@ -97,6 +97,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
 
 		<!-- Bindgen -->
 

--- a/owsi-core/owsi-core-components/owsi-core-component-infinispan/bindgen.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-infinispan/bindgen.properties
@@ -1,3 +1,5 @@
 scope=fr.openwide.core.test.infinispan,fr.openwide.core.infinispan,fr.openwide.core.commons,java.util,java.lang,org.infinispan.remoting.transport,org.jgroups
 skipBindKeyword=true
 bindingPathSuperClass=fr.openwide.core.commons.util.binding.AbstractCoreBinding
+
+skipAttribute.java.lang.Enum.describeConstable=true

--- a/owsi-core/owsi-core-components/owsi-core-component-infinispan/pom.xml
+++ b/owsi-core/owsi-core-components/owsi-core-component-infinispan/pom.xml
@@ -28,6 +28,11 @@
 		</dependency>
 		
 		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
+		
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-externallinkchecker/bindgen.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-externallinkchecker/bindgen.properties
@@ -1,4 +1,4 @@
-scope=fr.openwide.core.test.wicket.more,fr.openwide.core.wicket.more,fr.openwide.core.commons,java.util,java.lang
+scope=fr.openwide.core.jpa.externallinkchecker.business,java.util,java.lang
 skipBindKeyword=true
 bindingPathSuperClass=fr.openwide.core.commons.util.binding.AbstractCoreBinding
 

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/bindgen.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/bindgen.properties
@@ -1,3 +1,5 @@
 scope=fr.openwide.core.jpa.more,java.util,java.lang
 skipBindKeyword=true
 bindingPathSuperClass=fr.openwide.core.commons.util.binding.AbstractCoreBinding
+
+skipAttribute.java.lang.Enum.describeConstable=true

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-security/bindgen.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-security/bindgen.properties
@@ -1,3 +1,5 @@
 scope=fr.openwide.core.jpa.security,java.util,java.lang
 skipBindKeyword=true
 bindingPathSuperClass=fr.openwide.core.commons.util.binding.AbstractCoreBinding
+
+skipAttribute.java.lang.Enum.describeConstable=true

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/bindgen.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/bindgen.properties
@@ -1,3 +1,5 @@
 scope=fr.openwide.core,java.util,java.lang
 skipBindKeyword=true
 bindingPathSuperClass=fr.openwide.core.commons.util.binding.AbstractCoreBinding
+
+skipAttribute.java.lang.Enum.describeConstable=true


### PR DESCRIPTION
* javax.annotation n'est plus dans le OpenJDK 17; on l'ajoute en dépendance, qui sera ignorée avec java 8
* un nouvelle méthode describeConstable est ajoutée sur les enum et elle est incompatible avec bindgen. Comme on n'a pas besoin de ce binding, on skippe l'attribut

Note: il faut ajouter un runtime java 8 pour pouvoir lancer les tests avec succès via eclipse.

Je pense qu'il faut merger rapidement cette modification. C'est assez facile de revenir en arrière si nécessaire.