### PR TITLE
Upgrade jackson2-core from 2.9.4 to 2.10.5

### DIFF
--- a/owsi-core/owsi-core-parents/owsi-core-parent-maven-configuration-core/pom.xml
+++ b/owsi-core/owsi-core-parents/owsi-core-parent-maven-configuration-core/pom.xml
@@ -100,7 +100,7 @@
 
 		<owsi-core.json-lib.version>2.3</owsi-core.json-lib.version>
 		<owsi-core.jackson.version>1.9.13</owsi-core.jackson.version>
-		<owsi-core.jackson2-core.version>2.9.4</owsi-core.jackson2-core.version>
+		<owsi-core.jackson2-core.version>2.10.5</owsi-core.jackson2-core.version>
 		<owsi-core.jackson2-annotations.version>${owsi-core.jackson2-core.version}</owsi-core.jackson2-annotations.version>
 		<owsi-core.jackson2-databind.version>${owsi-core.jackson2-core.version}</owsi-core.jackson2-databind.version>
 		<owsi-core.jackson2-jaxrs.version>${owsi-core.jackson2-core.version}</owsi-core.jackson2-jaxrs.version>


### PR DESCRIPTION
Version 2.10.x is required to use spring-kafka module on apidae-sit