### PR TITLE
32154 elasticsearch issue - bascule recherche console en SQL

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/model/QueuedTaskHolder.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/model/QueuedTaskHolder.java
@@ -13,12 +13,6 @@ import javax.persistence.Version;
 
 import org.bindgen.Bindable;
 import org.hibernate.annotations.Type;
-import org.hibernate.search.annotations.Analyzer;
-import org.hibernate.search.annotations.DocumentId;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Fields;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.SortableField;
 import org.springframework.core.style.ToStringCreator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -29,11 +23,9 @@ import fr.openwide.core.commons.util.CloneUtils;
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
 import fr.openwide.core.jpa.more.business.task.util.TaskResult;
 import fr.openwide.core.jpa.more.business.task.util.TaskStatus;
-import fr.openwide.core.jpa.search.util.HibernateSearchAnalyzer;
 
 @Entity
 @Bindable
-@Indexed
 public class QueuedTaskHolder extends GenericEntity<Long, QueuedTaskHolder> {
 	private static final long serialVersionUID = 3926959721176678607L;
 
@@ -41,37 +33,25 @@ public class QueuedTaskHolder extends GenericEntity<Long, QueuedTaskHolder> {
 
 	@Id
 	@GeneratedValue
-	@DocumentId
 	private Long id;
 
 	@Column(nullable = false)
-	@Fields({ 
-		@Field(analyzer = @Analyzer(definition = HibernateSearchAnalyzer.TEXT)),
-		@Field(name = NAME_SORT_FIELD_NAME, analyzer = @Analyzer(definition = HibernateSearchAnalyzer.TEXT_SORT))
-	})
-	@SortableField(forField = NAME_SORT_FIELD_NAME)
 	@Type(type = "fr.openwide.core.jpa.hibernate.usertype.StringClobType")
 	private String name;
 
 	@Column(nullable = true)
-	@Field(analyzer = @Analyzer(definition = HibernateSearchAnalyzer.KEYWORD), indexNullAs = Field.DEFAULT_NULL_TOKEN)
 	private String queueId;
 
 	@Column(nullable = false)
-	@Field(analyzer = @Analyzer(definition = HibernateSearchAnalyzer.KEYWORD))
 	private String taskType;
 
 	@Column(nullable = false)
-	@Field
 	private Date creationDate;
 
-	@Field
 	private Date triggeringDate = null;
 
-	@Field
 	private Date startDate = null;
 
-	@Field
 	private Date endDate = null;
 
 	@Version
@@ -84,12 +64,10 @@ public class QueuedTaskHolder extends GenericEntity<Long, QueuedTaskHolder> {
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
-	@Field(analyzer = @Analyzer(definition = HibernateSearchAnalyzer.KEYWORD))
 	private TaskStatus status;
 	
 	@Column
 	@Enumerated(EnumType.STRING)
-	@Field(analyzer = @Analyzer(definition = HibernateSearchAnalyzer.KEYWORD))
 	private TaskResult result;
 
 	@Column

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/model/TaskTypesRegistry.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/model/TaskTypesRegistry.java
@@ -1,0 +1,27 @@
+package fr.openwide.core.jpa.more.business.task.model;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+import fr.openwide.core.jpa.more.business.task.service.ITaskTypeConfigurer;
+
+/**
+ * Holder for possible task types. Used to build administration UI, as retrieving it dynamically from database
+ * is computation intensive. See {@link ITaskTypeConfigurer} to configure types from your application.
+ */
+public class TaskTypesRegistry {
+
+	private final Set<String> taskTypes = new TreeSet<>();
+
+	public void addType(String type) {
+		if (type == null) {
+			throw new NullPointerException();
+		}
+		taskTypes.add(type);
+	}
+
+	public Set<String> getTypes() {
+		return Collections.unmodifiableSet(taskTypes);
+	}
+}

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/search/QueuedTaskHolderSearchQueryImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/search/QueuedTaskHolderSearchQueryImpl.java
@@ -1,66 +1,77 @@
 package fr.openwide.core.jpa.more.business.task.search;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 
-import fr.openwide.core.jpa.more.business.search.query.AbstractHibernateSearchSearchQuery;
+import org.apache.commons.lang3.time.DateUtils;
+
+import fr.openwide.core.jpa.more.business.search.query.AbstractJpaSearchQuery;
+import fr.openwide.core.jpa.more.business.task.model.QQueuedTaskHolder;
 import fr.openwide.core.jpa.more.business.task.model.QueuedTaskHolder;
 import fr.openwide.core.jpa.more.business.task.util.TaskResult;
 import fr.openwide.core.jpa.more.business.task.util.TaskStatus;
-import fr.openwide.core.jpa.more.util.binding.CoreJpaMoreBindings;
 
-public class QueuedTaskHolderSearchQueryImpl extends AbstractHibernateSearchSearchQuery<QueuedTaskHolder, QueuedTaskHolderSort>
+public class QueuedTaskHolderSearchQueryImpl extends AbstractJpaSearchQuery<QueuedTaskHolder, QueuedTaskHolderSort>
 		implements IQueuedTaskHolderSearchQuery {
 
 	public QueuedTaskHolderSearchQueryImpl() {
-		super(QueuedTaskHolder.class, QueuedTaskHolderSort.CREATION_DATE);
+		super(QQueuedTaskHolder.queuedTaskHolder);
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery name(String name) {
-		must(matchAllTermsIfGiven(name, CoreJpaMoreBindings.queuedTaskHolder().name()));
+		must(matchIfGiven(QQueuedTaskHolder.queuedTaskHolder.name, name));
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery statuses(Collection<TaskStatus> statuses) {
-		must(matchOneIfGiven(CoreJpaMoreBindings.queuedTaskHolder().status(), statuses));
+		must(matchOneIfGiven(QQueuedTaskHolder.queuedTaskHolder.status, statuses));
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery results(Collection<TaskResult> results) {
-		must(matchOneIfGiven(CoreJpaMoreBindings.queuedTaskHolder().result(), results));
+		must(matchOneIfGiven(QQueuedTaskHolder.queuedTaskHolder.result, results));
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery types(Collection<String> types) {
-		must(matchOneIfGiven(CoreJpaMoreBindings.queuedTaskHolder().taskType(), types));
+		must(matchOneIfGiven(QQueuedTaskHolder.queuedTaskHolder.taskType, types));
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery queueIds(Collection<String> queueIds) {
-		must(matchOneIfGiven(CoreJpaMoreBindings.queuedTaskHolder().queueId(), queueIds));
+		must(matchOneIfGiven(QQueuedTaskHolder.queuedTaskHolder.queueId, queueIds));
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery creationDate(Date creationDate) {
-		must(matchRangeMax(CoreJpaMoreBindings.queuedTaskHolder().creationDate(), creationDate));
+		if (creationDate != null) {
+			Date start = DateUtils.truncate(creationDate, Calendar.DATE);
+			Date end = DateUtils.addDays(DateUtils.truncate(creationDate, Calendar.DATE), 1);
+			must(QQueuedTaskHolder.queuedTaskHolder.creationDate.between(start, end));
+		}
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery startDate(Date startDate) {
-		must(matchRangeMax(CoreJpaMoreBindings.queuedTaskHolder().startDate(), startDate));
+		if (startDate != null) {
+			must(QQueuedTaskHolder.queuedTaskHolder.startDate.loe(startDate));
+		}
 		return this;
 	}
 
 	@Override
 	public IQueuedTaskHolderSearchQuery endDate(Date endDate) {
-		must(matchRangeMax(CoreJpaMoreBindings.queuedTaskHolder().endDate(), endDate));
+		if (endDate != null) {
+			must(QQueuedTaskHolder.queuedTaskHolder.endDate.loe(endDate));
+		}
 		return this;
 	}
 

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/search/QueuedTaskHolderSort.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/search/QueuedTaskHolderSort.java
@@ -2,25 +2,22 @@ package fr.openwide.core.jpa.more.business.task.search;
 
 import java.util.List;
 
-import org.apache.lucene.search.SortField;
-
 import com.google.common.collect.ImmutableList;
+import com.querydsl.core.types.OrderSpecifier;
 
-import fr.openwide.core.jpa.business.generic.model.GenericEntity;
 import fr.openwide.core.jpa.more.business.sort.ISort;
 import fr.openwide.core.jpa.more.business.sort.SortUtils;
-import fr.openwide.core.jpa.more.business.task.model.QueuedTaskHolder;
-import fr.openwide.core.jpa.more.util.binding.CoreJpaMoreBindings;
+import fr.openwide.core.jpa.more.business.task.model.QQueuedTaskHolder;
 
-public enum QueuedTaskHolderSort implements ISort<SortField> {
+public enum QueuedTaskHolderSort implements ISort<OrderSpecifier<?>> {
 	
 	CREATION_DATE {
 		@Override
-		public List<SortField> getSortFields(SortOrder sortOrder) {
+		public List<OrderSpecifier<?>> getSortFields(SortOrder sortOrder) {
 			return ImmutableList.of(
-					SortUtils.luceneLongSortField(this, sortOrder, CoreJpaMoreBindings.queuedTaskHolder().endDate().getPath(), NullSortValue.GREATEST),
-					SortUtils.luceneLongSortField(this, sortOrder, CoreJpaMoreBindings.queuedTaskHolder().startDate().getPath(), NullSortValue.GREATEST),
-					SortUtils.luceneSortField(this, sortOrder, SortField.Type.LONG, CoreJpaMoreBindings.queuedTaskHolder().creationDate().getPath())
+					SortUtils.orderSpecifier(this, sortOrder, QQueuedTaskHolder.queuedTaskHolder.endDate),
+					SortUtils.orderSpecifier(this, sortOrder, QQueuedTaskHolder.queuedTaskHolder.startDate),
+					SortUtils.orderSpecifier(this, sortOrder, QQueuedTaskHolder.queuedTaskHolder.creationDate)
 			);
 		}
 		
@@ -31,9 +28,9 @@ public enum QueuedTaskHolderSort implements ISort<SortField> {
 	},
 	NAME {
 		@Override
-		public List<SortField> getSortFields(SortOrder sortOrder) {
+		public List<OrderSpecifier<?>> getSortFields(SortOrder sortOrder) {
 			return ImmutableList.of(
-					SortUtils.luceneSortField(this, sortOrder, SortField.Type.STRING, QueuedTaskHolder.NAME_SORT_FIELD_NAME)
+					SortUtils.orderSpecifier(this, sortOrder, QQueuedTaskHolder.queuedTaskHolder.name)
 			);
 		}
 		
@@ -44,9 +41,9 @@ public enum QueuedTaskHolderSort implements ISort<SortField> {
 	},
 	ID {
 		@Override
-		public List<SortField> getSortFields(SortOrder sortOrder) {
+		public List<OrderSpecifier<?>> getSortFields(SortOrder sortOrder) {
 			return ImmutableList.of(
-					SortUtils.luceneSortField(this, sortOrder, SortField.Type.LONG, GenericEntity.ID_SORT)
+					SortUtils.orderSpecifier(this, sortOrder, QQueuedTaskHolder.queuedTaskHolder.id)
 			);
 		}
 		
@@ -60,10 +57,5 @@ public enum QueuedTaskHolderSort implements ISort<SortField> {
 	public abstract SortOrder getDefaultOrder();
 	
 	@Override
-	public abstract List<SortField> getSortFields(SortOrder sortOrder);
-	
-	// TODO RJO Sort : pourquoi on n'a pas ça dans l'interface ?
-	public List<SortField> getSortFields() {
-		return getSortFields(getDefaultOrder());
-	}
+	public abstract List<OrderSpecifier<?>> getSortFields(SortOrder sortOrder);
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/ITaskTypeConfigurer.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/ITaskTypeConfigurer.java
@@ -1,0 +1,15 @@
+package fr.openwide.core.jpa.more.business.task.service;
+
+import org.springframework.context.annotation.Configuration;
+
+import fr.openwide.core.jpa.more.business.task.model.TaskTypesRegistry;
+
+/**
+ * Allow applications to contribute task types. Used for administration UI. Implements this interface on
+ * @{@link Bean} or @{@link Configuration} to contribute your task types.
+ */
+public interface ITaskTypeConfigurer {
+
+	void configureTaskType(TaskTypesRegistry registry);
+
+}

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/QueuedTaskHolderServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/QueuedTaskHolderServiceImpl.java
@@ -1,5 +1,6 @@
 package fr.openwide.core.jpa.more.business.task.service;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -10,17 +11,20 @@ import fr.openwide.core.jpa.exception.SecurityServiceException;
 import fr.openwide.core.jpa.exception.ServiceException;
 import fr.openwide.core.jpa.more.business.task.dao.IQueuedTaskHolderDao;
 import fr.openwide.core.jpa.more.business.task.model.QueuedTaskHolder;
+import fr.openwide.core.jpa.more.business.task.model.TaskTypesRegistry;
 import fr.openwide.core.jpa.more.business.task.util.TaskStatus;
 
 public class QueuedTaskHolderServiceImpl extends GenericEntityServiceImpl<Long, QueuedTaskHolder> implements
 		IQueuedTaskHolderService {
 	
 	private IQueuedTaskHolderDao queuedTaskHolderDao;
+	private final TaskTypesRegistry typesRegistry;
 
 	@Autowired
-	public QueuedTaskHolderServiceImpl(IQueuedTaskHolderDao queuedTaskHolderDao) {
+	public QueuedTaskHolderServiceImpl(IQueuedTaskHolderDao queuedTaskHolderDao, TaskTypesRegistry typesRegistry) {
 		super(queuedTaskHolderDao);
 		this.queuedTaskHolderDao = queuedTaskHolderDao;
+		this.typesRegistry = typesRegistry;
 	}
 
 	@Override
@@ -54,9 +58,12 @@ public class QueuedTaskHolderServiceImpl extends GenericEntityServiceImpl<Long, 
 		return queuedTaskHolderDao.listConsumable(queueId);
 	}
 
+	/**
+	 * Task types extracted from {@link TaskTypesRegistry}, sorted in alphabetical order.
+	 */
 	@Override
 	public List<String> listTypes() {
-		return queuedTaskHolderDao.listTypes();
+		return new ArrayList<>(typesRegistry.getTypes());
 	}
 	
 	@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/config/spring/AbstractTaskManagementConfig.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/config/spring/AbstractTaskManagementConfig.java
@@ -1,6 +1,7 @@
 package fr.openwide.core.jpa.more.config.spring;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -12,8 +13,10 @@ import fr.openwide.core.jpa.more.business.CoreJpaMoreBusinessPackage;
 import fr.openwide.core.jpa.more.business.task.dao.IQueuedTaskHolderDao;
 import fr.openwide.core.jpa.more.business.task.dao.QueuedTaskHolderDaoImpl;
 import fr.openwide.core.jpa.more.business.task.model.IQueueId;
+import fr.openwide.core.jpa.more.business.task.model.TaskTypesRegistry;
 import fr.openwide.core.jpa.more.business.task.service.IQueuedTaskHolderManager;
 import fr.openwide.core.jpa.more.business.task.service.IQueuedTaskHolderService;
+import fr.openwide.core.jpa.more.business.task.service.ITaskTypeConfigurer;
 import fr.openwide.core.jpa.more.business.task.service.QueuedTaskHolderManagerImpl;
 import fr.openwide.core.jpa.more.business.task.service.QueuedTaskHolderServiceImpl;
 
@@ -33,8 +36,17 @@ public abstract class AbstractTaskManagementConfig {
 	}
 
 	@Bean
-	public IQueuedTaskHolderService queuedTaskHolderService(IQueuedTaskHolderDao queuedTaskHolderDao) {
-		return new QueuedTaskHolderServiceImpl(queuedTaskHolderDao);
+	public TaskTypesRegistry taskTypesRegistry(List<ITaskTypeConfigurer> configurers) {
+		TaskTypesRegistry registry = new TaskTypesRegistry();
+		for (ITaskTypeConfigurer configurer : configurers) {
+			configurer.configureTaskType(registry);
+		}
+		return registry;
+	}
+
+	@Bean
+	public IQueuedTaskHolderService queuedTaskHolderService(IQueuedTaskHolderDao queuedTaskHolderDao, TaskTypesRegistry registry) {
+		return new QueuedTaskHolderServiceImpl(queuedTaskHolderDao, registry);
 	}
 	
 	@Bean

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.html
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.html
@@ -13,7 +13,7 @@
 				<input wicket:id="name" type="text" class="form-control" />
 			</div>
 			<div class="form-group">
-				<select wicket:id="taskTypes" class="form-control" />
+				<input wicket:id="taskTypes" class="form-control" wicket:message="title:console.maintenance.task.filter.taskTypes.tooltip" />
 			</div>
 			<div class="form-group">
 				<select wicket:id="statuses" class="form-control" />
@@ -23,6 +23,12 @@
 			</div>
 			<div class="form-group">
 				<select wicket:id="queueIds" class="form-control" />
+			</div>
+			<div class="form-group">
+				<div class="input-group">
+					<input wicket:id="date" class="form-control" type="text" />
+					<div class="input-group-addon" style="padding: 5px 12px;"><label wicket:for="date"><span class="fa fa-calendar" /></label></div>
+				</div>
 			</div>
 			<button type="submit" class="btn btn-primary">
 				<span class="fa fa-search" />

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.html
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.html
@@ -13,7 +13,7 @@
 				<input wicket:id="name" type="text" class="form-control" />
 			</div>
 			<div class="form-group">
-				<input wicket:id="taskTypes" class="form-control" wicket:message="title:console.maintenance.task.filter.taskTypes.tooltip" />
+				<select wicket:id="taskTypes" class="form-control" />
 			</div>
 			<div class="form-group">
 				<select wicket:id="statuses" class="form-control" />

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.java
@@ -1,6 +1,11 @@
 package fr.openwide.core.wicket.more.console.maintenance.task.component;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponent;
@@ -10,12 +15,16 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.util.convert.ConversionException;
 
 import fr.openwide.core.jpa.more.business.task.util.TaskResult;
 import fr.openwide.core.jpa.more.business.task.util.TaskStatus;
+import fr.openwide.core.spring.util.StringUtils;
 import fr.openwide.core.wicket.markup.html.basic.CountLabel;
 import fr.openwide.core.wicket.more.console.maintenance.task.model.QueuedTaskHolderDataProvider;
+import fr.openwide.core.wicket.more.markup.html.form.DatePicker;
 import fr.openwide.core.wicket.more.markup.html.form.LabelPlaceholderBehavior;
+import fr.openwide.core.wicket.more.util.DatePattern;
 
 public class TaskFilterPanel extends Panel {
 
@@ -63,7 +72,7 @@ public class TaskFilterPanel extends Panel {
 		name.add(new LabelPlaceholderBehavior());
 		filterForm.add(name);
 
-		FormComponent<Collection<String>> taskTypes = new TaskTypeListMultipleChoice("taskTypes",
+		FormComponent<Collection<String>> taskTypes = new TypeChoice("taskTypes",
 				queuedTaskHolderDataProvider.getTaskTypesModel());
 		filterForm.add(taskTypes);
 
@@ -78,5 +87,32 @@ public class TaskFilterPanel extends Panel {
 		FormComponent<Collection<TaskResult>> results = new TaskResultListMultipleChoice("results",
 				queuedTaskHolderDataProvider.getResultsModel());
 		filterForm.add(results);
+		
+		FormComponent<Date> date = new DatePicker("date", queuedTaskHolderDataProvider.getCreationDateModel(), DatePattern.SHORT_DATE);
+		date.setRequired(true);
+		filterForm.add(date);
+	}
+
+	public static class TypeChoice extends TextField<Collection<String>> {
+		
+		private static final long serialVersionUID = 417472287897054950L;
+		
+		public TypeChoice(String id, IModel<Collection<String>> model) {
+			super(id, model);
+			setConvertEmptyInputStringToNull(false);
+		}
+		
+		@Override
+		protected List<String> convertValue(String[] value) throws ConversionException {
+			if (value == null || value.length == 0 || value[0] == null) {
+				return new ArrayList<>();
+			}
+			return StringUtils.splitAsList(value[0].trim(), "|");
+		}
+		
+		@Override
+		protected String getModelValue() {
+			return Optional.ofNullable(getModelObject()).map(list -> list.stream().collect(Collectors.joining("|"))).orElse("");
+		}
 	}
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/component/TaskFilterPanel.java
@@ -1,11 +1,7 @@
 package fr.openwide.core.wicket.more.console.maintenance.task.component;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponent;
@@ -15,11 +11,9 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.util.convert.ConversionException;
 
 import fr.openwide.core.jpa.more.business.task.util.TaskResult;
 import fr.openwide.core.jpa.more.business.task.util.TaskStatus;
-import fr.openwide.core.spring.util.StringUtils;
 import fr.openwide.core.wicket.markup.html.basic.CountLabel;
 import fr.openwide.core.wicket.more.console.maintenance.task.model.QueuedTaskHolderDataProvider;
 import fr.openwide.core.wicket.more.markup.html.form.DatePicker;
@@ -72,7 +66,7 @@ public class TaskFilterPanel extends Panel {
 		name.add(new LabelPlaceholderBehavior());
 		filterForm.add(name);
 
-		FormComponent<Collection<String>> taskTypes = new TypeChoice("taskTypes",
+		FormComponent<Collection<String>> taskTypes = new TaskTypeListMultipleChoice("taskTypes",
 				queuedTaskHolderDataProvider.getTaskTypesModel());
 		filterForm.add(taskTypes);
 
@@ -91,28 +85,5 @@ public class TaskFilterPanel extends Panel {
 		FormComponent<Date> date = new DatePicker("date", queuedTaskHolderDataProvider.getCreationDateModel(), DatePattern.SHORT_DATE);
 		date.setRequired(true);
 		filterForm.add(date);
-	}
-
-	public static class TypeChoice extends TextField<Collection<String>> {
-		
-		private static final long serialVersionUID = 417472287897054950L;
-		
-		public TypeChoice(String id, IModel<Collection<String>> model) {
-			super(id, model);
-			setConvertEmptyInputStringToNull(false);
-		}
-		
-		@Override
-		protected List<String> convertValue(String[] value) throws ConversionException {
-			if (value == null || value.length == 0 || value[0] == null) {
-				return new ArrayList<>();
-			}
-			return StringUtils.splitAsList(value[0].trim(), "|");
-		}
-		
-		@Override
-		protected String getModelValue() {
-			return Optional.ofNullable(getModelObject()).map(list -> list.stream().collect(Collectors.joining("|"))).orElse("");
-		}
 	}
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/model/QueuedTaskHolderDataProvider.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/maintenance/task/model/QueuedTaskHolderDataProvider.java
@@ -46,6 +46,7 @@ public class QueuedTaskHolderDataProvider extends AbstractSearchQueryDataProvide
 
 	public QueuedTaskHolderDataProvider() {
 		super();
+		creationDateModel.setObject(new Date());
 		Injector.get().inject(this);
 	}
 

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/resources/CoreWicketConsoleResources.utf8.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/resources/CoreWicketConsoleResources.utf8.properties
@@ -106,7 +106,6 @@ console.maintenance.task.list.empty=Aucune tâche trouvée.
 
 console.maintenance.task.filter.title=Recherche
 console.maintenance.task.filter.search=Rechercher
-console.maintenance.task.filter.taskTypes.tooltip=Séparez les valeurs par des pipes (|)
 
 console.maintenance.task.manager.title=Etat du gestionnaire de tâches
 console.maintenance.task.manager.status.active=Le gestionnaire de tâches est actif.

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/resources/CoreWicketConsoleResources.utf8.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/console/resources/CoreWicketConsoleResources.utf8.properties
@@ -106,6 +106,7 @@ console.maintenance.task.list.empty=Aucune tâche trouvée.
 
 console.maintenance.task.filter.title=Recherche
 console.maintenance.task.filter.search=Rechercher
+console.maintenance.task.filter.taskTypes.tooltip=Séparez les valeurs par des pipes (|)
 
 console.maintenance.task.manager.title=Etat du gestionnaire de tâches
 console.maintenance.task.manager.status.active=Le gestionnaire de tâches est actif.


### PR DESCRIPTION
Dans le cas d'un grand nombre de tâches, la réindexation devient problématique.

La recherche est implémentable en SQL, donc bascule, en traitant les 2 cas particuliers :
* le count global est trop long (20 secondes) ; hors la pagination l'exécute par défaut. On ajoute par défaut un filtre sur la date de création pour alléger le count
* la récupération des types de tâches, réalisé dynamiquement avec un SELECT DISTINCT est trop long aussi (environ 20 secondes). On met en place un mécanisme permettant aux applications de déclarer leurs types de tâches

Cette mise à jour nécessite au niveau applicatif d'implémenter `ITaskTypeConfigurer`.