### PR TITLE
Mise à jour de Flyway 4.0.3 -> 9.22.3

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-externallinkchecker/src/test/resources/jpa-externallinkchecker-test.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-externallinkchecker/src/test/resources/jpa-externallinkchecker-test.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/test/resources/jpa-more-test.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/test/resources/jpa-more-test.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-security/src/test/resources/jpa-security-test.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-security/src/test/resources/jpa-security-test.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/pom.xml
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/pom.xml
@@ -24,8 +24,8 @@
 		
 		<!-- Database dependencies -->
 		<dependency>
-			<groupId>com.impossibl.pgjdbc-ng</groupId>
-			<artifactId>pgjdbc-ng</artifactId>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
 		</dependency>
 		
 		<!-- Hibernate dependencies -->

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/config/spring/AbstractJpaConfig.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/config/spring/AbstractJpaConfig.java
@@ -9,19 +9,20 @@ import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.search.BooleanQuery;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.springframework.aop.Advisor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.PropertiesFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.core.io.Resource;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.Resource;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -63,15 +64,16 @@ public abstract class AbstractJpaConfig {
 	@Bean(initMethod = "migrate", value = { "flyway", "databaseInitialization" })
 	@Profile("flyway")
 	public Flyway flyway(DataSource dataSource, FlywayConfiguration flywayConfiguration) {
-		Flyway flyway = new Flyway();
-		flyway.setDataSource(dataSource);
-		flyway.setSchemas(flywayConfiguration.getSchemas()); 
-		flyway.setTable(flywayConfiguration.getTable());
-		flyway.setLocations(StringUtils.split(flywayConfiguration.getLocations(), ","));
-		flyway.setBaselineOnMigrate(true);
+		ClassicConfiguration configuration = new ClassicConfiguration();
+		configuration.setDataSource(dataSource);
+		configuration.setSchemas(flywayConfiguration.getSchemas()); 
+		configuration.setTable(flywayConfiguration.getTable());
+		configuration.setLocationsAsStrings(StringUtils.split(flywayConfiguration.getLocations(), ","));
+		configuration.setBaselineOnMigrate(true);
 		// difficult to handle this case for the moment; we ignore mismatching checksums
 		// TODO allow developers to handle mismatches during their tests.
-		flyway.setValidateOnMigrate(false);
+		configuration.setValidateOnMigrate(false);
+		Flyway flyway = new Flyway(configuration);
 		return flyway;
 	}
 

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/config/spring/AbstractJpaConfig.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/config/spring/AbstractJpaConfig.java
@@ -66,7 +66,7 @@ public abstract class AbstractJpaConfig {
 	public Flyway flyway(DataSource dataSource, FlywayConfiguration flywayConfiguration) {
 		ClassicConfiguration configuration = new ClassicConfiguration();
 		configuration.setDataSource(dataSource);
-		configuration.setSchemas(flywayConfiguration.getSchemas()); 
+		configuration.setSchemas(StringUtils.split(flywayConfiguration.getSchemas(), ',')); 
 		configuration.setTable(flywayConfiguration.getTable());
 		configuration.setLocationsAsStrings(StringUtils.split(flywayConfiguration.getLocations(), ","));
 		configuration.setBaselineOnMigrate(true);

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/jpa/batch/AbstractTestHibernateBatchExecutor.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/jpa/batch/AbstractTestHibernateBatchExecutor.java
@@ -15,10 +15,10 @@ import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionAttribute;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.querydsl.jpa.impl.JPAQuery;
 
-import fr.openwide.core.commons.util.functional.Joiners;
 import fr.openwide.core.jpa.batch.executor.BatchExecutorCreator;
 import fr.openwide.core.jpa.batch.runnable.ReadWriteBatchRunnable;
 import fr.openwide.core.jpa.exception.SecurityServiceException;
@@ -98,7 +98,7 @@ public abstract class AbstractTestHibernateBatchExecutor extends AbstractJpaCore
 		
 		@Override
 		public void preExecutePartition(List<T> partition) {
-			LOGGER.warn("Executing partition: " + Joiners.onComma().join(partition));
+			LOGGER.warn("Executing partition: " + Joiner.on(",").join(partition));
 		}
 		
 		@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/jpa/batch/AbstractTestSimpleHibernateBatchExecutor.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/jpa/batch/AbstractTestSimpleHibernateBatchExecutor.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -179,7 +180,7 @@ public abstract class AbstractTestSimpleHibernateBatchExecutor extends AbstractT
 	private static class SequentialFailingRunnable<T> extends PartitionCountingRunnable<T> {
 		@Override
 		public void preExecutePartition(List<T> partition) {
-			LOGGER.warn("Executing partition: " + Joiners.onComma().join(partition));
+			LOGGER.warn("Executing partition: " + Joiner.on(",").join(partition));
 		}
 		
 		@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/jpa/batch/TestMultithreadedBatchExecutor.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/jpa/batch/TestMultithreadedBatchExecutor.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 
 import fr.openwide.core.commons.util.functional.Joiners;
@@ -51,7 +52,7 @@ public class TestMultithreadedBatchExecutor extends AbstractTestHibernateBatchEx
 		executor.run(Person.class.getSimpleName(), personIds, new ReadWriteBatchRunnable<Long>() {
 			@Override
 			public void preExecutePartition(List<Long> partition) {
-				LOGGER.warn("Executing partition: " + Joiners.onComma().join(partition));
+				LOGGER.warn("Executing partition: " + Joiner.on(",").join(partition));
 			}
 			
 			@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/metamodel/TestMetaModel.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/java/fr/openwide/core/test/metamodel/TestMetaModel.java
@@ -18,11 +18,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.impossibl.postgres.utils.guava.Joiner;
 
 import fr.openwide.core.jpa.config.spring.provider.IJpaConfigurationProvider;
 import fr.openwide.core.jpa.hibernate.dialect.PerTableSequenceStyleGenerator;
@@ -80,7 +80,7 @@ public class TestMetaModel extends AbstractJpaCoreTestCase {
 			Iterator<DynaBean> tablesResultSet =
 					new ResultSetDynaClass(
 						connection.getMetaData().getTables(null, schemaPattern, relationPattern, types),
-						false,
+						true,
 						true
 					).iterator();
 			Iterator<JdbcRelation> tables =

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/resources/owsi-hibernate.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/test/resources/owsi-hibernate.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-components/owsi-core-component-rest-jersey2/src/test/resources/rest-client.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-rest-jersey2/src/test/resources/rest-client.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-components/owsi-core-component-rest-jersey2/src/test/resources/rest-server.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-rest-jersey2/src/test/resources/rest-server.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/resources/owsi-hibernate.properties
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/resources/owsi-hibernate.properties
@@ -4,8 +4,8 @@ propertyNamesForInfoLogLevel=db.jdbcUrl,db.user
 ##
 ## DB connexion
 ##
-db.type=pgsql
-db.jdbcUrl=jdbc:pgsql://localhost:6432/owsicore_test
+db.type=postgresql
+db.jdbcUrl=jdbc:postgresql://localhost:6432/owsicore_test
 db.user=owsicore_test
 db.password=owsicore_test
 db.minIdle=5

--- a/owsi-core/owsi-core-parents/owsi-core-parent-maven-configuration-core/pom.xml
+++ b/owsi-core/owsi-core-parents/owsi-core-parent-maven-configuration-core/pom.xml
@@ -147,7 +147,7 @@
 		<owsi-core.less4j.version>1.17.2</owsi-core.less4j.version>
 		<owsi-core.jsass.version>3.3.0</owsi-core.jsass.version>
 
-		<owsi-core.flywaydb.version>4.0.3</owsi-core.flywaydb.version>
+		<owsi-core.flywaydb.version>6.0.8</owsi-core.flywaydb.version>
 		<!-- infinispan >= 8.0 requires java 8 -->
 		<owsi-core.infinispan.version>13.0.12.Final</owsi-core.infinispan.version>
 

--- a/owsi-core/owsi-core-parents/owsi-core-parent-maven-configuration-core/pom.xml
+++ b/owsi-core/owsi-core-parents/owsi-core-parent-maven-configuration-core/pom.xml
@@ -37,7 +37,7 @@
 
 		<owsi-core.joda-time.version>2.9.2</owsi-core.joda-time.version>
 
-		<owsi-core.postgresql.version>9.4.1208.jre7</owsi-core.postgresql.version>
+		<owsi-core.postgresql.version>42.7.4</owsi-core.postgresql.version>
 		<owsi-core.pgjdbc-ng.version>0.7.1</owsi-core.pgjdbc-ng.version>
 		<owsi-core.oracle10g.version>10.2.0.5</owsi-core.oracle10g.version>
 		<owsi-core.mysql.version>5.1.14</owsi-core.mysql.version>
@@ -147,7 +147,7 @@
 		<owsi-core.less4j.version>1.17.2</owsi-core.less4j.version>
 		<owsi-core.jsass.version>3.3.0</owsi-core.jsass.version>
 
-		<owsi-core.flywaydb.version>6.0.8</owsi-core.flywaydb.version>
+		<owsi-core.flywaydb.version>9.22.3</owsi-core.flywaydb.version>
 		<!-- infinispan >= 8.0 requires java 8 -->
 		<owsi-core.infinispan.version>13.0.12.Final</owsi-core.infinispan.version>
 


### PR DESCRIPTION
Mise à jour de Flyway. Attention aux éléments suivant :

* La version de Flyway utilisée ne supporte pas des migrations mélangeant des modifications transactionnelles et non-transactionnelles (ce n'est pas le cas d'usage courant)
* Cette version de Flyway ne supporte plus les migrations Java avec injection Spring (rupture de compatibilité lors du passage 7.x -> 8.x)
* La version 9.22.3 de Flyway permet d'assurer une compatibilité PostgreSQL 12 -> 15
* Attention, il faut obligatoirement mettre un chemin dans flyway.locations (avant, il était possible de mettre un nom de package)