### PR TITLE
43284 Optimisation des opérations sur le cache pour le gestionnaire de tâches

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/dao/IQueuedTaskHolderDao.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/dao/IQueuedTaskHolderDao.java
@@ -36,7 +36,7 @@ public interface IQueuedTaskHolderDao extends IGenericEntityDao<Long, QueuedTask
 	
 	List<QueuedTaskHolder> listConsumable();
 	
-	List<QueuedTaskHolder> listConsumable(String queueId);
+	List<QueuedTaskHolder> listConsumable(String queueId, Integer limit);
 
 	List<String> listTypes();
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/dao/QueuedTaskHolderDaoImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/dao/QueuedTaskHolderDaoImpl.java
@@ -89,12 +89,16 @@ public class QueuedTaskHolderDaoImpl extends GenericEntityDaoImpl<Long, QueuedTa
 	}
 	
 	@Override
-	public List<QueuedTaskHolder> listConsumable(String queueId) {
+	public List<QueuedTaskHolder> listConsumable(String queueId, Integer limit) {
 		JPQLQuery<QueuedTaskHolder> query = getConsumableBaseQuery();
 		if (queueId != null) {
 			query.where(qQueuedTaskHolder.queueId.eq(queueId));
 		} else {
 			query.where(qQueuedTaskHolder.queueId.isNull());
+		}
+		
+		if(limit != null) {
+			query.limit(limit.longValue());
 		}
 		
 		return query.fetch();

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/IQueuedTaskHolderService.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/IQueuedTaskHolderService.java
@@ -28,9 +28,10 @@ public interface IQueuedTaskHolderService extends IGenericEntityService<Long, Qu
 	/**
 	 * Gets the tasks that may be run
 	 * @param queueId
+	 * @param limit
 	 * @return
 	 * @throws ServiceException
 	 * @throws SecurityServiceException
 	 */
-	List<QueuedTaskHolder> getListConsumable(String queueId) throws ServiceException, SecurityServiceException;
+	List<QueuedTaskHolder> getListConsumable(String queueId,Integer limit) throws ServiceException, SecurityServiceException;
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/QueuedTaskHolderServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/task/service/QueuedTaskHolderServiceImpl.java
@@ -54,8 +54,8 @@ public class QueuedTaskHolderServiceImpl extends GenericEntityServiceImpl<Long, 
 	}
 	
 	@Override
-	public List<QueuedTaskHolder> getListConsumable(String queueId)  throws ServiceException, SecurityServiceException {
-		return queuedTaskHolderDao.listConsumable(queueId);
+	public List<QueuedTaskHolder> getListConsumable(String queueId, Integer limit)  throws ServiceException, SecurityServiceException {
+		return queuedTaskHolderDao.listConsumable(queueId, limit);
 	}
 
 	/**

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/config/spring/JpaMoreTaskApplicationPropertyRegistryConfig.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/config/spring/JpaMoreTaskApplicationPropertyRegistryConfig.java
@@ -3,6 +3,8 @@ package fr.openwide.core.jpa.more.config.spring;
 import static fr.openwide.core.jpa.more.property.JpaMoreTaskPropertyIds.*;
 import static fr.openwide.core.jpa.more.property.JpaMoreTaskPropertyIds.START_MODE;
 import static fr.openwide.core.jpa.more.property.JpaMoreTaskPropertyIds.STOP_TIMEOUT;
+import static fr.openwide.core.jpa.more.property.JpaMoreTaskPropertyIds.INIT_TASKS_FROM_DATABASE_LIMIT;
+import static fr.openwide.core.jpa.more.property.JpaMoreTaskPropertyIds.INIT_TASKS_FROM_DATABASE_DELAY_MINUTES;
 
 import org.springframework.context.annotation.Configuration;
 
@@ -20,6 +22,8 @@ public class JpaMoreTaskApplicationPropertyRegistryConfig extends AbstractApplic
 		registry.registerInteger(QUEUE_NUMBER_OF_THREADS_TEMPLATE, 1);
 		registry.registerLong(QUEUE_START_DELAY_TEMPLATE, 0l);
 		registry.registerBoolean(QUEUE_START_EXECUTION_CONTEXT_WAIT_READY_TEMPLATE, true);
+		registry.registerInteger(INIT_TASKS_FROM_DATABASE_LIMIT, 200);
+		registry.registerInteger(INIT_TASKS_FROM_DATABASE_DELAY_MINUTES, 2);
 	}
 
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/property/JpaMoreTaskPropertyIds.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/property/JpaMoreTaskPropertyIds.java
@@ -33,5 +33,8 @@ public final class JpaMoreTaskPropertyIds extends AbstractPropertyIds {
 		Objects.requireNonNull(queueId);
 		return QUEUE_START_EXECUTION_CONTEXT_WAIT_READY_TEMPLATE.create(queueId);
 	}
+	
+	public static final ImmutablePropertyId<Integer> INIT_TASKS_FROM_DATABASE_LIMIT = immutable("init.tasks.from.database.limit");
+	public static final ImmutablePropertyId<Integer> INIT_TASKS_FROM_DATABASE_DELAY_MINUTES = immutable("init.tasks.from.database.delay");
 
 }


### PR DESCRIPTION
Les optimisations suivantes sont effectuées pour réduire les occurrences de récupération du cache : 
- Doubler le délai des traitement d'initialisation des tâches dans le cache à 2 minutes (paramétrable init.tasks.from.database.delay )
- Passer sur un Fixed delay au lieu d'un fixed rate afin d'ajouter un délai entre 2 traitements. 
- Limiter le nombre d'offre récupérées en bdd à chaque itération (Paramétrable = 200 par défaut : init.tasks.from.database.limit). 
- Lorsque faire se peut, récupérer 1 seule fois le contenu du cache, et effectuer le traitement sur une copie du cache (par exemple lors de l’initialisation des tâches, récupérer une copie du contenu du cache pour pré-filtrer les identifiants à ajouter, avant de les ajouter réellement).